### PR TITLE
Fixed an issue with Code Contracts where (pure) methods not marked [P…

### DIFF
--- a/May.sln
+++ b/May.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "May", "May\May.csproj", "{37468DFC-8378-4F4F-94F2-39F5C1AB8C5A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MayTest", "MayTest\MayTest.csproj", "{B27038A2-7CFF-41B0-8FB6-DD38BBBD740C}"

--- a/May/IMayHaveValue.cs
+++ b/May/IMayHaveValue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.Contracts;
 
 namespace Strilanc.Value {
     ///<summary>
@@ -13,6 +14,7 @@ namespace Strilanc.Value {
     [EditorBrowsable(EditorBrowsableState.Never)]
     public interface IMayHaveValue : IEquatable<IMayHaveValue> {
         ///<summary>Determines if this potential value contains a value or not.</summary>
+        [Pure]
         bool HasValue { get; }
     }
 }

--- a/May/May.cs
+++ b/May/May.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Strilanc.Value {
     ///<summary>
@@ -14,20 +15,24 @@ namespace Strilanc.Value {
         ///Note: All forms of no value are equal, including May.NoValue, May&lt;T&gt;.NoValue, May&lt;AnyOtherT&gt;.NoValue, default(May&lt;T&gt;) and new May&lt;T&gt;().
         ///Note: Null is NOT equivalent to new May&lt;object&gt;(null) and neither is equivalent to new May&lt;string&gt;(null).
         ///</summary>
+        [Pure]
         public static May<T> NoValue { get { return default(May<T>); } }
 
         private readonly T _value;
         private readonly bool _hasValue;
         ///<summary>Determines if this potential value contains a value or not.</summary>
+        [Pure]
         public bool HasValue { get { return _hasValue; } }
 
         ///<summary>Constructs a potential value containing the given value.</summary>
+        [Pure]
         public May(T value) {
             this._hasValue = true;
             this._value = value;
         }
 
         ///<summary>Matches this potential value into either a function expecting a value or a function expecting no value, returning the result.</summary>
+        [Pure]
         public TOut Match<TOut>(Func<T, TOut> valueProjection, Func<TOut> alternativeFunc) {
             if (valueProjection == null) throw new ArgumentNullException("valueProjection");
             if (alternativeFunc == null) throw new ArgumentNullException("alternativeFunc");

--- a/May/May.csproj
+++ b/May/May.csproj
@@ -11,9 +11,14 @@
     <RootNamespace>Strilanc.Value</RootNamespace>
     <AssemblyName>May</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile1</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/May/MayExtensions.cs
+++ b/May/MayExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 
 namespace Strilanc.Value {
     ///<summary>Utility methods for the generic May type.</summary>
@@ -8,55 +9,67 @@ namespace Strilanc.Value {
         ///Note: All forms of no value are equal, including May.NoValue, May&lt;T&gt;.NoValue, May&lt;AnyOtherT&gt;.NoValue, default(May&lt;T&gt;) and new May&lt;T&gt;().
         ///Note: Null is NOT equivalent to new May&lt;object&gt;(null) and neither is equivalent to new May&lt;string&gt;(null).
         ///</summary>
+        [Pure]
         public static MayNoValue NoValue { get { return default(MayNoValue); } }
 
         ///<summary>Returns a potential value containing the given value.</summary>
+        [Pure]
         public static May<T> Maybe<T>(this T value) {
             return new May<T>(value);
         }
         ///<summary>Matches this potential value either into a function expecting a value or against an alternative value.</summary>
+        [Pure]
         public static TOut Match<TIn, TOut>(this May<TIn> potentialValue, Func<TIn, TOut> valueProjection, TOut alternative) {
             if (valueProjection == null) throw new ArgumentNullException("valueProjection");
             return potentialValue.Match(valueProjection, () => alternative);
         }
         ///<summary>Returns the potential result of potentially applying the given function to this potential value.</summary>
+        [Pure]
         public static May<TOut> Bind<TIn, TOut>(this May<TIn> potentialValue, Func<TIn, May<TOut>> projection) {
             if (projection == null) throw new ArgumentNullException("projection");
             return potentialValue.Match(projection, () => NoValue);
         }
         ///<summary>Returns the value contained in the given potential value, if any, or else the result of evaluating the given alternative value function.</summary>
+        [Pure]
         public static T Else<T>(this May<T> potentialValue, Func<T> alternativeFunc) {
             if (alternativeFunc == null) throw new ArgumentNullException("alternativeFunc");
             return potentialValue.Match(e => e, alternativeFunc);
         }
         ///<summary>Flattens a doubly-potential value, with the result containing a value only if both levels contained a value.</summary>
+        [Pure]
         public static May<T> Unwrap<T>(this May<May<T>> potentialValue) {
             return potentialValue.Bind(e => e);
         }
         ///<summary>Returns the value contained in the given potential value, if any, or else the result of evaluating the given alternative potential value function.</summary>
+        [Pure]
         public static May<T> Else<T>(this May<T> potentialValue, Func<May<T>> alternative) {
             if (alternative == null) throw new ArgumentNullException("alternative");
             return potentialValue.Match(e => e.Maybe(), alternative);
         }
         ///<summary>Returns the value contained in the given potential value, if any, or else the given alternative value.</summary>
+        [Pure]
         public static T Else<T>(this May<T> potentialValue, T alternative) {
             return potentialValue.Else(() => alternative);
         }
         ///<summary>Returns the value contained in the given potential value, if any, or else the given alternative potential value.</summary>
+        [Pure]
         public static May<T> Else<T>(this May<T> potentialValue, May<T> alternative) {
             return potentialValue.Else(() => alternative);
         }
         ///<summary>Returns the result of potentially applying a function to this potential value.</summary>
+        [Pure]        
         public static May<TOut> Select<TIn, TOut>(this May<TIn> value, Func<TIn, TOut> projection) {
             if (projection == null) throw new ArgumentNullException("projection");
             return value.Bind(e => projection(e).Maybe());
         }
         ///<summary>Returns the same value, unless the contained value does not match the filter in which case a no value is returned.</summary>
+        [Pure]
         public static May<T> Where<T>(this May<T> value, Func<T, bool> filter) {
             if (filter == null) throw new ArgumentNullException("filter");
             return value.Bind(e => filter(e) ? e.Maybe() : NoValue);
         }
         ///<summary>Projects optional values, returning a no value if anything along the way is a no value.</summary>
+        [Pure]
         public static May<TOut> SelectMany<TIn, TMid, TOut>(this May<TIn> source,
                                                             Func<TIn, May<TMid>> maySelector,
                                                             Func<TIn, TMid, TOut> resultSelector) {
@@ -65,6 +78,7 @@ namespace Strilanc.Value {
             return source.Bind(s => maySelector(s).Select(m => resultSelector(s, m)));
         }
         ///<summary>Combines the values contained in several potential values with a projection function, returning no value if any of the inputs contain no value.</summary>
+        [Pure]
         public static May<TOut> Combine<TIn1, TIn2, TOut>(this May<TIn1> potentialValue1,
                                                           May<TIn2> potentialValue2,
                                                           Func<TIn1, TIn2, TOut> resultSelector) {
@@ -74,6 +88,7 @@ namespace Strilanc.Value {
                    select resultSelector(v1, v2);
         }
         ///<summary>Combines the values contained in several potential values with a projection function, returning no value if any of the inputs contain no value.</summary>
+        [Pure]
         public static May<TOut> Combine<TIn1, TIn2, TIn3, TOut>(this May<TIn1> potentialValue1,
                                                                 May<TIn2> potentialValue2,
                                                                 May<TIn3> potentialValue3,
@@ -85,6 +100,7 @@ namespace Strilanc.Value {
                    select resultSelector(v1, v2, v3);
         }
         ///<summary>Combines the values contained in several potential values with a projection function, returning no value if any of the inputs contain no value.</summary>
+        [Pure]
         public static May<TOut> Combine<TIn1, TIn2, TIn3, TIn4, TOut>(this May<TIn1> potentialValue1,
                                                                       May<TIn2> potentialValue2,
                                                                       May<TIn3> potentialValue3,
@@ -102,6 +118,7 @@ namespace Strilanc.Value {
         /// No effect if the potential value is no value.
         /// Returns an IMayHaveValue that has a value iff the action was run.
         /// </summary>
+        [Pure]
         public static IMayHaveValue IfHasValueThenDo<T>(this May<T> potentialValue, Action<T> hasValueAction) {
             if (hasValueAction == null) throw new ArgumentNullException("hasValueAction");
             return potentialValue.Select(e => {
@@ -110,17 +127,20 @@ namespace Strilanc.Value {
             });
         }
         ///<summary>Runs the given no value action if the given potential value does not contain a value, and otherwise does nothing.</summary>
+        [Pure]
         public static void ElseDo(this IMayHaveValue potentialValue, Action noValueAction) {
             if (potentialValue == null) throw new ArgumentNullException("potentialValue");
             if (noValueAction == null) throw new ArgumentNullException("noValueAction");
             if (!potentialValue.HasValue) noValueAction();
         }
         ///<summary>Returns the value contained in the given potential value, if any, or else the type's default value.</summary>
+        [Pure]
         public static T ElseDefault<T>(this May<T> potentialValue) {
             return potentialValue.Else(default(T));
         }
 
         ///<summary>Returns the value contained in the potential value, or throws an InvalidOperationException if it contains no value.</summary>
+        [Pure]
         public static T ForceGetValue<T>(this May<T> potentialValue) {
             return potentialValue.Match(
                 e => e, 

--- a/May/MayNoValue.cs
+++ b/May/MayNoValue.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Strilanc.Value {
     ///<summary>
@@ -12,6 +13,7 @@ namespace Strilanc.Value {
     [DebuggerDisplay("{ToString()}")]
     public struct MayNoValue : IMayHaveValue {
         ///<summary>Determines if this potential value contains a value or not (it doesn't).</summary>
+        [Pure]
         public bool HasValue { get { return false; } }
         ///<summary>Returns the hash code for a lack of potential value.</summary>
         public override int GetHashCode() {

--- a/May/MayUtilities.cs
+++ b/May/MayUtilities.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Strilanc.Value {
     ///<summary>Utility methods that involve May&lt;T&gt; but with a focus on other types.</summary>
     public static class MayUtilities {
         ///<summary>Returns the value contained in the given potential value as a nullable type, returning null if there is no contained value.</summary>
+        [Pure]
         public static T? AsNullable<T>(this May<T> potentialValue) where T : struct {
             return potentialValue.Select(e => (T?)e).ElseDefault();
         }
 
         ///<summary>Returns the value contained in the given nullable value as a potential value, with null corresponding to no value.</summary>
+        [Pure]
         public static May<T> AsMay<T>(this T? potentialValue) where T : struct {
             if (!potentialValue.HasValue) return May.NoValue;
             return potentialValue.Value;
@@ -20,6 +23,7 @@ namespace Strilanc.Value {
         /// Returns the result of using a folder function to combine all the items in the sequence into one aggregate item.
         /// If the sequence is empty, the result is NoValue.
         /// </summary>
+        [Pure]
         public static May<T> MayAggregate<T>(this IEnumerable<T> sequence, Func<T, T, T> folder) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             if (folder == null) throw new ArgumentNullException("folder");
@@ -32,6 +36,7 @@ namespace Strilanc.Value {
         /// Returns the minimum value in a sequence, as determined by the given comparer or else the type's default comparer.
         /// If the sequence is empty, the result is NoValue.
         /// </summary>
+        [Pure]
         public static May<T> MayMin<T>(this IEnumerable<T> sequence, IComparer<T> comparer = null) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             var c = comparer ?? Comparer<T>.Default;
@@ -42,6 +47,7 @@ namespace Strilanc.Value {
         /// Returns the maximum value in a sequence, as determined by the given comparer or else the type's default comparer.
         /// If the sequence is empty, the result is NoValue.
         /// </summary>
+        [Pure]
         public static May<T> MayMax<T>(this IEnumerable<T> sequence, IComparer<T> comparer = null) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             var c = comparer ?? Comparer<T>.Default;
@@ -52,6 +58,7 @@ namespace Strilanc.Value {
         /// Returns the minimum value in a sequence, as determined by projecting the items and using the given comparer or else the type's default comparer.
         /// If the sequence is empty, the result is NoValue.
         /// </summary>
+        [Pure]
         public static May<TItem> MayMinBy<TItem, TCompare>(this IEnumerable<TItem> sequence, Func<TItem, TCompare> projection, IComparer<TCompare> comparer = null) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             var c = comparer ?? Comparer<TCompare>.Default;
@@ -65,6 +72,7 @@ namespace Strilanc.Value {
         /// Returns the maximum value in a sequence, as determined by projecting the items and using the given comparer or else the type's default comparer.
         /// If the sequence is empty, the result is NoValue.
         /// </summary>
+        [Pure]
         public static May<TItem> MayMaxBy<TItem, TCompare>(this IEnumerable<TItem> sequence, Func<TItem, TCompare> projection, IComparer<TCompare> comparer = null) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             var c = comparer ?? Comparer<TCompare>.Default;
@@ -75,6 +83,7 @@ namespace Strilanc.Value {
         }
 
         ///<summary>Returns the first item in a sequence, or else NoValue if the sequence is empty.</summary>
+        [Pure]
         public static May<T> MayFirst<T>(this IEnumerable<T> sequence) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             using (var e = sequence.GetEnumerator())
@@ -84,6 +93,7 @@ namespace Strilanc.Value {
         }
 
         ///<summary>Returns the last item in a sequence, or else NoValue if the sequence is empty.</summary>
+        [Pure]
         public static May<T> MayLast<T>(this IEnumerable<T> sequence) {
             if (sequence == null) throw new ArgumentNullException("sequence");
 
@@ -98,6 +108,7 @@ namespace Strilanc.Value {
         }
 
         ///<summary>Returns the single item in a sequence, NoValue if the sequence is empty, or throws an exception if there is more than one item.</summary>
+        [Pure]
         public static May<T> MaySingle<T>(this IEnumerable<T> sequence) {
             if (sequence == null) throw new ArgumentNullException("sequence");
 
@@ -114,6 +125,7 @@ namespace Strilanc.Value {
         /// Enumerates the values in the potential values in the sequence.
         /// The potential values that contain no value are skipped.
         /// </summary>
+        [Pure]
         public static IEnumerable<T> WhereHasValue<T>(this IEnumerable<May<T>> sequence) {
             return sequence.Where(e => e.HasValue).Select(e => (T)e);
         }
@@ -122,6 +134,7 @@ namespace Strilanc.Value {
         /// Enumerates the values in all the potential values in the sequence.
         /// However, if any of the potential values contains no value then the entire result is no value.
         /// </summary>
+        [Pure]
         public static May<IEnumerable<T>> MayAll<T>(this IEnumerable<May<T>> sequence) {
             if (sequence == null) throw new ArgumentNullException("sequence");
             var result = new List<T>();


### PR DESCRIPTION
…ure] were unable to inspect the contents of a May.  Eg. Contract.Ensures(Contract.Result<Tuple<bool, May<OnboardingError>>>().Item2.Match(v => v != null, () => true); fails to compile unless Match is marked [Pure].

All non-operator methods marked [Pure].  Built and tested successfully.
Note: VS2015 made changes to .sln file--VS2015 reports resulting solution works with VS2010 SP1 and later.
